### PR TITLE
Moving post processing args

### DIFF
--- a/examples/ball_reactor.ipynb
+++ b/examples/ball_reactor.ipynb
@@ -57,6 +57,9 @@
     "    simulation_particles_per_batch=10,  # this will need increasing to obtain accurate results\n",
     ")\n",
     "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "neutronics_model.process_results()\n",
+    "\n",
     "# prints the results to screen\n",
     "print('TBR', neutronics_model.results['TBR'])"
    ]
@@ -81,7 +84,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/ball_reactor_minimal.ipynb
+++ b/examples/ball_reactor_minimal.ipynb
@@ -44,6 +44,10 @@
     "    simulation_particles_per_batch=10,  # this will need increasing to obtain accurate results\n",
     "\n",
     ")\n",
+    "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "neutronics_model.process_results()\n",
+    "\n",
     "print(neutronics_model.results)\n"
    ]
   },
@@ -74,7 +78,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/ball_reactor_source_plot.ipynb
+++ b/examples/ball_reactor_source_plot.ipynb
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/center_column_study_reactor.ipynb
+++ b/examples/center_column_study_reactor.ipynb
@@ -38,12 +38,16 @@
     "        'firstwall_mat': 'eurofer',\n",
     "        'blanket_mat': 'Li4SiO4'},\n",
     "    cell_tallies=['heating'],\n",
-    "    simulation_batches=2,\n",
-    "    simulation_particles_per_batch=10, # this will need increasing to obtain accurate results\n",
     ")\n",
     "\n",
     "# starts the neutronics simulation\n",
-    "neutronics_model.simulate()\n",
+    "neutronics_model.simulate(\n",
+    "    simulation_batches=2,\n",
+    "    simulation_particles_per_batch=10,  # this would need increasing to get a accurate result\n",
+    ")\n",
+    "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "neutronics_model.process_results()\n",
     "\n",
     "# converts the results to mega watts\n",
     "total_heat_in_MW = neutronics_model.results['firstwall_mat_heating']['Watts']['result'] / 1e6\n",
@@ -70,7 +74,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/center_column_study_reactor_minimal.ipynb
+++ b/examples/center_column_study_reactor_minimal.ipynb
@@ -39,6 +39,9 @@
     "    simulation_particles_per_batch=10, # this will need increasing to obtain accurate results\n",
     ")\n",
     "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "neutronics_model.process_results()\n",
+    "\n",
     "# prints the results\n",
     "print(neutronics_model.results)\n"
    ]
@@ -70,7 +73,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/component_based_parameter_study.ipynb
+++ b/examples/component_based_parameter_study.ipynb
@@ -40,6 +40,9 @@
     "    simulation_particles_per_batch=10,  # settings are low to reduce time required\n",
     ")\n",
     "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "my_model.process_results()\n",
+    "\n",
     "# extracts the heat from the results dictionary\n",
     "heat = my_model.results['center_column_shield_mat_heating']['Watts']['result']\n",
     "\n",
@@ -73,7 +76,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/openmc_logo_example.ipynb
+++ b/examples/openmc_logo_example.ipynb
@@ -57,7 +57,11 @@
     "my_model.simulate(\n",
     "    simulation_batches=2,  # this should be increased to get a better mesh tally result\n",
     "    simulation_particles_per_batch=10,  # this should be increased to get a better mesh tally result\n",
-    ")"
+    ")\n",
+    "\n",
+    "\n",
+    "# extracts and processes the results from the statepoint file\n",
+    "my_model.process_results()"
    ]
   },
   {
@@ -93,7 +97,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/submersion_reactor.ipynb
+++ b/examples/submersion_reactor.ipynb
@@ -133,12 +133,21 @@
    "hash": "71893251c0b0cd78b546a9c905312457257aecf63dc5b51c6968316964f80317"
   },
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit ('cq': conda)",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": ""
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/text_example.ipynb
+++ b/examples/text_example.ipynb
@@ -61,7 +61,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -857,7 +857,7 @@ class NeutronicsModel:
         fusion_energy_per_pulse: Optional[float] = None,
         cell_tally_results_filename: Optional[str] = "results.json",
         statepoint_filename: Optional[str] = None,
-        ) -> dict:
+    ) -> dict:
         """Extracts simulation results from the statepoint file. Applies post
         processing to the results taking into account user specified fusion
         power or fusion energy per pulse. If 3d mesh tallies are specified then
@@ -879,7 +879,7 @@ class NeutronicsModel:
             cell_tally_results_filename: the filename to use when saving the
                 cell tallies to file.
             statepoint_filename: the name of the statepoint file to extract
-                results from and process. Defaults to None which makes use of 
+                results from and process. Defaults to None which makes use of
                 NeutronicsModel.statepoint_filename which is set when the
                 NeutronicsModel.simulate method is called.
 

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -856,6 +856,7 @@ class NeutronicsModel:
         fusion_power: Optional[float] = None,
         fusion_energy_per_pulse: Optional[float] = None,
         cell_tally_results_filename: Optional[str] = "results.json",
+        statepoint_filename: Optional[str] = None,
         ) -> dict:
         """Extracts simulation results from the statepoint file. Applies post
         processing to the results taking into account user specified fusion
@@ -877,13 +878,25 @@ class NeutronicsModel:
                 tallies are extended to include Joules deposited for the pulse.
             cell_tally_results_filename: the filename to use when saving the
                 cell tallies to file.
+            statepoint_filename: the name of the statepoint file to extract
+                results from and process. Defaults to None which makes use of 
+                NeutronicsModel.statepoint_filename which is set when the
+                NeutronicsModel.simulate method is called.
 
         Returns:
             A dictionary of results
         """
 
+        if statepoint_filename is None:
+            statepoint_filename = self.statepoint_filename
+        if statepoint_filename is None:
+            msg = ("statepoint_filename was not provided and 
+                   "NeutronicsModel.statepoint_filename has not been set. Try"
+                   "simulating the model first with NeutronicsModel.simulate")
+            raise ValueError(msg)
+
         self.results = get_neutronics_results_from_statepoint_file(
-            statepoint_filename=self.statepoint_filename,
+            statepoint_filename=statepoint_filename,
             fusion_power=fusion_power,
             fusion_energy_per_pulse=fusion_energy_per_pulse,
         )

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -890,8 +890,8 @@ class NeutronicsModel:
         if statepoint_filename is None:
             statepoint_filename = self.statepoint_filename
         if statepoint_filename is None:
-            msg = ("statepoint_filename was not provided and 
-                   "NeutronicsModel.statepoint_filename has not been set. Try"
+            msg = ("statepoint_filename was not provided and "
+                   "NeutronicsModel.statepoint_filename has not been set. Try "
                    "simulating the model first with NeutronicsModel.simulate")
             raise ValueError(msg)
 

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -63,16 +63,6 @@ class NeutronicsModel:
         mesh_3d_corners: The upper and lower corner locations for the 3d
             mesh. This sets the location of the mesh. Defaults to None which
             uses the geometry in the h5m file to set the corners.
-        fusion_power: the power in watts emitted by the fusion reaction
-            recalling that each DT fusion reaction emits 17.6 MeV or
-            2.819831e-12 Joules. Intended use for steady state reactors.
-            Providing an input can result in additional entries in the post
-            processed tally results. e.g heating tallies are extended to include
-            rate of heating deposited in Watts.
-        fusion_energy_per_pulse: the amount of energy released by the pulse.
-            Intended use for pulsed machines. Providing an input can result in
-            additional entries in the post processed tally results. e.g heating
-            tallies are extended to include Joules deposited for the pulse.
         bounding_box: the lower left and upper right corners of the geometry
             used by the 2d and 3d mesh when no corners are specified. Can be
             found with NeutronicsModel.find_bounding_box but includes graveyard
@@ -96,8 +86,6 @@ class NeutronicsModel:
         mesh_3d_corners: Optional[
             Tuple[Tuple[float, float, float], Tuple[float, float, float]]
         ] = None,
-        fusion_power: Optional[float] = None,
-        fusion_energy_per_pulse: Optional[float] = None,
         photon_transport: Optional[bool] = True,
         # convert from watts to activity source_activity
         bounding_box: Tuple[
@@ -118,8 +106,6 @@ class NeutronicsModel:
         self.mesh_2d_corners = mesh_2d_corners
         self.mesh_3d_corners = mesh_3d_corners
         self.photon_transport = photon_transport
-        self.fusion_power = fusion_power
-        self.fusion_energy_per_pulse = fusion_energy_per_pulse
 
         self.model = None
         self.results = None
@@ -779,7 +765,6 @@ class NeutronicsModel:
     def simulate(
         self,
         verbose: Optional[bool] = True,
-        cell_tally_results_filename: Optional[str] = "results.json",
         threads: Optional[int] = None,
         export_xml: Optional[bool] = True,
         simulation_batches: Optional[int] = 100,
@@ -792,8 +777,6 @@ class NeutronicsModel:
         Arguments:
             verbose: Print the output from OpenMC (True) to the terminal or
                 don't print the OpenMC output (False).
-            cell_tally_results_filename: the filename to use when saving the
-                cell tallies to file.
             threads: Sets the number of OpenMP threads used for the simulation.
                  None takes all available threads by default.
             simulation_batches: the number of batch to simulate.
@@ -865,16 +848,53 @@ class NeutronicsModel:
 
         self.statepoint_filename = self.model.run(
             output=verbose, threads=threads)
-        self.results = get_neutronics_results_from_statepoint_file(
-            statepoint_filename=self.statepoint_filename,
-            fusion_power=self.fusion_power,
-            fusion_energy_per_pulse=self.fusion_energy_per_pulse,
-        )
-
-        with open(cell_tally_results_filename, "w") as outfile:
-            json.dump(self.results, outfile, indent=4, sort_keys=True)
 
         return self.statepoint_filename
+
+    def process_results(
+        self,
+        fusion_power: Optional[float] = None,
+        fusion_energy_per_pulse: Optional[float] = None,
+        cell_tally_results_filename: Optional[str] = "results.json",
+        ) -> dict:
+        """Extracts simulation results from the statepoint file. Applies post
+        processing to the results taking into account user specified fusion
+        power or fusion energy per pulse. If 3d mesh tallies are specified then
+        vtk files will be produced. If 2d mesh tallies are specified then png
+        images will be produced. The cell tallies results will be output to
+        a json file.
+
+        Args:
+            fusion_power: the power in watts emitted by the fusion reaction
+                recalling that each DT fusion reaction emits 17.6 MeV or
+                2.819831e-12 Joules. Intended use for steady state reactors.
+                Providing an input can result in additional entries in the post
+                processed tally results. e.g heating tallies are extended to include
+                rate of heating deposited in Watts.
+            fusion_energy_per_pulse: the amount of energy released by the pulse.
+                Intended use for pulsed machines. Providing an input can result in
+                additional entries in the post processed tally results. e.g heating
+                tallies are extended to include Joules deposited for the pulse.
+            cell_tally_results_filename: the filename to use when saving the
+                cell tallies to file.
+
+        Returns:
+            A dictionary of results
+        """
+
+        self.results = get_neutronics_results_from_statepoint_file(
+            statepoint_filename=self.statepoint_filename,
+            fusion_power=fusion_power,
+            fusion_energy_per_pulse=fusion_energy_per_pulse,
+        )
+
+        # outputs the cell tally results as a json file
+        if cell_tally_results_filename is not None:
+            with open(cell_tally_results_filename, "w") as outfile:
+                json.dump(self.results, outfile, indent=4, sort_keys=True)
+        
+        return self.results
+
 
     def export_html(
         self,

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -77,6 +77,8 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             simulation_particles_per_batch=20,
         )
 
+        my_model.process_results()
+
         assert my_model.results["TBR"]["result"] > 0.0
 
     def test_bounding_box_size(self):


### PR DESCRIPTION
moving fusion_energy_per_pulse and fusion_power to a new process_results method

the process results method was previously included in the simulate method which had some disadvantages as users would have to re-simulate when changing the source strength.

Now users can post process the statepoint file with different source strengths without having to re-simulate the model