### PR TITLE
refactored making use of dagmc_h5m_file_inspector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,33 +18,33 @@ jobs:
       - run:
           name: run test_NeutronicModel
           command: 
-            pytest tests/test_neutronics_model.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml
+            pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 
       - run:
           name: run test_shape_neutronics
           command: 
-            pytest tests/test_shape_neutronics.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml
+            pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 
       - run:
           name: run test_reactor_neutronics
           command: 
-            pytest tests/test_reactor_neutronics.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml
+            pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 
-      - run:
-          name: run test_neutronics_utils
-          command: 
-            pytest tests/test_neutronics_utils.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      # - run:
+      #     name: run test_neutronics_utils
+      #     command: 
+      #       pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 
       - run:
           name: run test_example_neutronics_simulations
           command: 
-            pytest tests/test_example_neutronics_simulations.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml
+            pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 
       # TODO add example notebooks
       # - run:
       #     name: run notebook_testing
       #     command: 
-      #       pytest tests/notebook_testing.py -v --cov=openmc-dagmc_wrapper --cov-append --cov-report term --cov-report xml --junitxml=test-reports/junit.xml
+      #       pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml --junitxml=test-reports/junit.xml
 
 
       - store_test_results:

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -22,24 +22,13 @@ jobs:
       - name: install package
         run: |
           python setup.py install
+
       - name: run tests
         run: |
-          apt-get install tree
-          wget https://github.com/fusion-energy/neutronics_workflow/archive/refs/tags/v0.0.1.tar.gz
-          tar -xvzf v0.0.1.tar.gz -C tests
-          tree
-          pytest tests/test_neutronics_model.py -vv
-
-      # - name: run tests
-      #   run: |
-      #     apt-get install tree
-      #     tree tests
-      #     pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     tree tests
-      #     pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-      #     tree tests
-      #     curl -s https://codecov.io/bash
+          pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          curl -s https://codecov.io/bash

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -28,7 +28,8 @@ jobs:
           tree tests
           pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xmlpytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           tree tests

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -29,6 +29,6 @@ jobs:
           pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          # pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           curl -s https://codecov.io/bash

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -26,11 +26,12 @@ jobs:
         run: |
           apt-get install tree
           tree tests
-          pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          tree tests
           pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
           tree tests
           curl -s https://codecov.io/bash

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -25,13 +25,21 @@ jobs:
       - name: run tests
         run: |
           apt-get install tree
-          tree tests
-          pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          tree tests
-          pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-          tree tests
-          curl -s https://codecov.io/bash
+          wget https://github.com/fusion-energy/neutronics_workflow/archive/refs/tags/v0.0.1.tar.gz
+          tar -xvzf v0.0.1.tar.gz -C tests
+          tree
+          pytest tests/test_neutronics_model.py -vv
+
+      # - name: run tests
+      #   run: |
+      #     apt-get install tree
+      #     tree tests
+      #     pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     tree tests
+      #     pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+      #     tree tests
+      #     curl -s https://codecov.io/bash

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -24,5 +24,12 @@ jobs:
           python setup.py install
       - name: run tests
         run: |
-          bash run_tests.sh
+          apt-get install tree
+          tree tests
+          pytest tests/notebook_testing.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xmlpytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+          tree tests
           curl -s https://codecov.io/bash

--- a/openmc_dagmc_wrapper/__init__.py
+++ b/openmc_dagmc_wrapper/__init__.py
@@ -1,6 +1,4 @@
 from .utils import get_neutronics_results_from_statepoint_file
-from .utils import find_material_groups_in_h5m
-from .utils import find_volume_ids_in_h5m
 from .utils import create_initial_particles
 from .utils import extract_points_from_initial_source
 from .utils import silently_remove_file

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -123,7 +123,7 @@ class NeutronicsModel:
         if isinstance(value, str):
             if not Path(value).is_file():
                 msg = f"h5m_filename provided ({value}) does not exist"
-                raise TypeError(msg)
+                raise FileNotFoundError(msg)
             self._h5m_filename = value
         else:
             msg = "NeutronicsModelFromReactor.h5m_filename should be a string"
@@ -135,7 +135,12 @@ class NeutronicsModel:
 
     @tet_mesh_filename.setter
     def tet_mesh_filename(self, value):
-        if isinstance(value, (str, type(None))):
+        if isinstance(value, str):
+            if not Path(value).is_file():
+                msg = f"tet_mesh_filename provided ({value}) does not exist"
+                raise FileNotFoundError(msg)
+            self._tet_mesh_filename = value
+        if isinstance(value, type(None)):
             self._tet_mesh_filename = value
         else:
             msg = "NeutronicsModelFromReactor.tet_mesh_filename should be a string"

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -121,7 +121,12 @@ class NeutronicsModel:
     @h5m_filename.setter
     def h5m_filename(self, value):
         if isinstance(value, str):
-            self._h5m_filename = value
+            if not Path(value).is_file():
+                msg = f"h5m_filename provided ({value}) does not exist"
+                raise TypeError(msg)
+
+
+                self._h5m_filename = value
         else:
             msg = "NeutronicsModelFromReactor.h5m_filename should be a string"
             raise TypeError(msg)

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -124,9 +124,7 @@ class NeutronicsModel:
             if not Path(value).is_file():
                 msg = f"h5m_filename provided ({value}) does not exist"
                 raise TypeError(msg)
-
-
-                self._h5m_filename = value
+            self._h5m_filename = value
         else:
             msg = "NeutronicsModelFromReactor.h5m_filename should be a string"
             raise TypeError(msg)

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -284,7 +284,7 @@ class NeutronicsModel:
         # # checks all the required materials are present
         for reactor_material in self.materials.keys():
             if reactor_material not in materials_in_h5m:
-                msg = (f"material with tag {reactor_material} was not found in"
+                msg = (f"material with tag {reactor_material} was not found in "
                        "the dagmc h5m file")
                 raise ValueError(msg)
 
@@ -295,7 +295,7 @@ class NeutronicsModel:
 
         if required_number_of_materials != len(self.materials.keys()):
             msg = (
-                f"the NeutronicsModel.materials does not match the material"
+                f"the NeutronicsModel.materials does not match the material "
                 "tags in the dagmc h5m file. Materials in h5m file "
                 f"{materials_in_h5m}. Materials provided {self.materials.keys()}")
             raise ValueError(msg)

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -282,7 +282,7 @@ class NeutronicsModel:
 
         materials_in_h5m = di.get_materials_from_h5m(self.h5m_filename)
         # # checks all the required materials are present
-        for reactor_material in self.materials.items():
+        for reactor_material in self.materials.keys():
             if reactor_material not in materials_in_h5m:
                 msg = (f"material with tag {reactor_material} was not found in"
                        "the dagmc h5m file")

--- a/openmc_dagmc_wrapper/neutronics_model.py
+++ b/openmc_dagmc_wrapper/neutronics_model.py
@@ -288,7 +288,12 @@ class NeutronicsModel:
                        "the dagmc h5m file")
                 raise ValueError(msg)
 
-        if len(materials_in_h5m) != len(self.materials.keys()):
+        if 'graveyard' in materials_in_h5m:
+            required_number_of_materials = len(materials_in_h5m) -1
+        else:
+            required_number_of_materials = len(materials_in_h5m)
+
+        if required_number_of_materials != len(self.materials.keys()):
             msg = (
                 f"the NeutronicsModel.materials does not match the material"
                 "tags in the dagmc h5m file. Materials in h5m file "

--- a/openmc_dagmc_wrapper/utils.py
+++ b/openmc_dagmc_wrapper/utils.py
@@ -81,13 +81,6 @@ def plotly_trace(
     return trace
 
 
-def load_moab_file(filename: str):
-    """Loads a h5m into a Moab Core object and returns the object"""
-    moab_core = core.Core()
-    moab_core.load_file(filename)
-    return moab_core
-
-
 def silently_remove_file(filename: str):
     """Allows files to be deleted without printing warning messages int the
     terminal. input XML files for OpenMC are deleted prior to running
@@ -96,72 +89,6 @@ def silently_remove_file(filename: str):
         os.remove(filename)
     except OSError:
         pass  # in some cases the file will not exist
-
-
-def find_volume_ids_in_h5m(filename: Optional[str] = "dagmc.h5m") -> List[str]:
-    """Reads in a DAGMC h5m file and uses PyMoab to find the volume ids of the
-    volumes in the file
-
-    Arguments:
-        filename:
-
-    Returns:
-        The filename of the h5m file created
-    """
-
-    # create a new PyMOAB instance and load the specified DAGMC file
-    moab_core = load_moab_file(filename)
-
-    # retrieve the category tag on the instance
-    cat_tag = moab_core.tag_get_handle(types.CATEGORY_TAG_NAME)
-
-    # get the id tag
-    gid_tag = moab_core.tag_get_handle(types.GLOBAL_ID_TAG_NAME)
-
-    # get the set of entities using the provided category tag name
-    # (0 means search on the instance's root set)
-    ents = moab_core.get_entities_by_type_and_tag(
-        0, types.MBENTITYSET, [cat_tag], ["Volume"]
-    )
-
-    # retrieve the IDs of the entities
-    ids = moab_core.tag_get_data(gid_tag, ents).flatten()
-
-    return sorted(list(ids))
-
-
-def find_material_groups_in_h5m(
-        filename: Optional[str] = "dagmc.h5m") -> List[str]:
-    """Reads in a DAGMC h5m file and uses mbsize to find the names of the
-    material groups in the file
-
-    Arguments:
-        filename:
-
-    Returns:
-        The filename of the h5m file created
-    """
-
-    try:
-        terminal_output = subprocess.check_output(
-            "mbsize -ll {} | grep 'mat:'".format(filename),
-            shell=True,
-            universal_newlines=True,
-        )
-    except BaseException:
-        raise ValueError(
-            "mbsize failed, check MOAB is install and the MOAB/build/bin "
-            "folder is in the path directory (Linux and Mac) or set as an "
-            "enviromental varible (Windows)"
-        )
-
-    list_of_mats = terminal_output.split()
-    list_of_mats = list(filter(lambda a: a != "=", list_of_mats))
-    list_of_mats = list(filter(lambda a: a != "NAME", list_of_mats))
-    list_of_mats = list(filter(lambda a: a != "EXTRA_NAME0", list_of_mats))
-    list_of_mats = list(set(list_of_mats))
-
-    return list_of_mats
 
 
 def _save_2d_mesh_tally_as_png(score: str, filename: str, tally) -> str:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,4 +4,4 @@ pytest tests/test_neutronics_model.py -v --cov=openmc_dagmc_wrapper --cov-append
 pytest tests/test_reactor_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 pytest tests/test_shape_neutronics.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
 pytest tests/test_example_neutronics_simulations.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
-pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml
+# pytest tests/test_neutronics_utils.py -v --cov=openmc_dagmc_wrapper --cov-append --cov-report term --cov-report xml

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setuptools.setup(
         "plotly",
         "defusedxml",
         "nbformat",
-        "nbconvert"
+        "nbconvert",
+        "dagmc_h5m_file_inspector",
     ],
     # openmc, dagmc, moab are also needed and embree and double down are also
     # optionally needed but not avaible on PyPi

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-
+import tarfile
 import neutronics_material_maker as nmm
 import openmc
 import openmc_dagmc_wrapper
@@ -14,18 +14,16 @@ class TestShape(unittest.TestCase):
 
     def setUp(self):
 
-        url = "https://github.com/fusion-energy/neutronics_workflow/raw/main/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+        if not Path("tests/v0.0.1.tar.gz").is_file():
+            url = "https://github.com/fusion-energy/neutronics_workflow/archive/refs/tags/v0.0.1.tar.gz"
+            urllib.request.urlretrieve(url, "tests/v0.0.1.tar.gz")
 
-        local_filename = "dagmc_bigger.h5m"
+            tar = tarfile.open("tests/v0.0.1.tar.gz", "r:gz")
+            tar.extractall("tests")
+            tar.close()
 
-        if not Path(local_filename).is_file():
-            r = requests.get(url, stream=True)
-            with open(local_filename, "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024):
-                    if chunk:
-                        f.write(chunk)
-
-        self.h5m_filename_bigger = local_filename
+        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
         self.material_description = {
             "tungsten": "tungsten",
@@ -33,19 +31,6 @@ class TestShape(unittest.TestCase):
             "flibe": "FLiNaBe",
             "copper": "copper",
         }
-
-        url = "https://github.com/fusion-energy/neutronics_workflow/raw/main/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-
-        local_filename = "dagmc_smaller.h5m"
-
-        if not Path(local_filename).is_file():
-            r = requests.get(url, stream=True)
-            with open(local_filename, "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024):
-                    if chunk:  # filter out keep-alive new chunks
-                        f.write(chunk)
-
-        self.h5m_filename_smaller = local_filename
 
         # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
         # directions and 14MeV neutrons

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -720,8 +720,11 @@ class TestShape(unittest.TestCase):
             """Attempts to simulate without a dagmc_smaller.h5m file which should fail
             with a FileNotFoundError"""
 
+            import shutil
+            shutil.copy(self.h5m_filename_smaller, '.')
+
             my_model = openmc_dagmc_wrapper.NeutronicsModel(
-                h5m_filename=self.h5m_filename_smaller,
+                h5m_filename='dagmc.h5m',
                 source=self.source,
                 materials={"mat1": "WC"},
             )
@@ -731,7 +734,7 @@ class TestShape(unittest.TestCase):
             os.system("touch materials.xml")
             os.system("touch settings.xml")
             os.system("touch tallies.xml")
-            os.system("rm dagmc_smaller.h5m")
+            os.system("rm dagmc.h5m")
 
             my_model.simulate()
 

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -7,7 +7,6 @@ import openmc
 import openmc_dagmc_wrapper
 import urllib.request
 
-
 class TestShape(unittest.TestCase):
     """Tests the NeutronicsModel with a Shape as the geometry input
     including neutronics simulations using"""
@@ -22,8 +21,8 @@ class TestShape(unittest.TestCase):
             tar.extractall("tests")
             tar.close()
 
-        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_bigger = "neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_smaller = "neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
         self.material_description = {
             "tungsten": "tungsten",
@@ -47,6 +46,7 @@ class TestShape(unittest.TestCase):
                 nmm.Material.from_library("eurofer"),
             ],
         )
+
 
     def simulation_with_previous_h5m_file(self):
         """This performs a simulation using previously created h5m file"""
@@ -738,6 +738,7 @@ class TestShape(unittest.TestCase):
         self.assertRaises(
             FileNotFoundError,
             test_missing_h5m_file_error_handling)
+
 
     def test_neutronics_model_attributes(self):
         """Makes a BallReactor neutronics model and simulates the TBR"""

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -21,8 +21,8 @@ class TestShape(unittest.TestCase):
             tar.extractall("tests")
             tar.close()
 
-        self.h5m_filename_bigger = "neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_smaller = "neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
         self.material_description = {
             "tungsten": "tungsten",

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -39,6 +39,16 @@ class TestShape(unittest.TestCase):
         source.energy = openmc.stats.Discrete([14e6], [1])
         self.source = source
 
+        self.blanket_material = nmm.Material.from_mixture(
+            fracs=[0.8, 0.2],
+            materials=[
+                nmm.Material.from_library("SiC"),
+                nmm.Material.from_library("eurofer"),
+            ],
+        )
+
+
+
     def simulation_with_previous_h5m_file(self):
         """This performs a simulation using previously created h5m file"""
 
@@ -731,37 +741,13 @@ class TestShape(unittest.TestCase):
             test_missing_h5m_file_error_handling)
 
 
-class TestNeutronicsBallReactor(unittest.TestCase):
-    """Tests the NeutronicsModel with a BallReactor as the geometry input
-    including neutronics simulations"""
-
-    def setUp(self):
-
-        # makes a homogenised material for the blanket from lithium lead and
-        # eurofer
-        self.blanket_material = nmm.Material.from_mixture(
-            fracs=[0.8, 0.2],
-            materials=[
-                nmm.Material.from_library("SiC"),
-                nmm.Material.from_library("eurofer"),
-            ],
-        )
-
-        self.source = openmc.Source()
-        # sets the location of the source to x=0 y=0 z=0
-        self.source.space = openmc.stats.Point((0, 0, 0))
-        # sets the direction to isotropic
-        self.source.angle = openmc.stats.Isotropic()
-        # sets the energy distribution to 100% 14MeV neutrons
-        self.source.energy = openmc.stats.Discrete([14e6], [1])
-
     def test_neutronics_model_attributes(self):
         """Makes a BallReactor neutronics model and simulates the TBR"""
 
         # makes the neutronics material
         my_model = openmc_dagmc_wrapper.NeutronicsModel(
             source=openmc.Source(),
-            h5m_filename="placeholder.h5m",
+            h5m_filename=self.h5m_filename_smaller,
             materials={
                 "inboard_tf_coils_mat": "copper",
                 "mat1": "WC",
@@ -773,7 +759,7 @@ class TestNeutronicsBallReactor(unittest.TestCase):
             cell_tallies=["TBR", "flux", "heating"],
         )
 
-        assert my_model.h5m_filename == "placeholder.h5m"
+        assert my_model.h5m_filename == self.h5m_filename_smaller
 
         assert my_model.materials == {
             "inboard_tf_coils_mat": "copper",

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -5,8 +5,7 @@ import tarfile
 import neutronics_material_maker as nmm
 import openmc
 import openmc_dagmc_wrapper
-import requests
-
+import urllib.request
 
 class TestShape(unittest.TestCase):
     """Tests the NeutronicsModel with a Shape as the geometry input

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -22,8 +22,8 @@ class TestShape(unittest.TestCase):
             tar.extractall("tests")
             tar.close()
 
-        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.1/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.1/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
         self.material_description = {
             "tungsten": "tungsten",

--- a/tests/test_neutronics_utils.py
+++ b/tests/test_neutronics_utils.py
@@ -1,11 +1,11 @@
-import json
-import os
-import unittest
-from pathlib import Path
+# import json
+# import os
+# import unittest
+# from pathlib import Path
 
-import openmc
-import openmc_dagmc_wrapper
-import requests
+# import openmc
+# import openmc_dagmc_wrapper
+# import requests
 
 
 # class TestNeutronicsUtilityFunctions(unittest.TestCase):

--- a/tests/test_neutronics_utils.py
+++ b/tests/test_neutronics_utils.py
@@ -8,20 +8,20 @@ import openmc_dagmc_wrapper
 import requests
 
 
-class TestNeutronicsUtilityFunctions(unittest.TestCase):
-    def setUp(self):
+# class TestNeutronicsUtilityFunctions(unittest.TestCase):
+#     def setUp(self):
 
-        url = "https://github.com/fusion-energy/neutronics_workflow/raw/main/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+#         url = "https://github.com/fusion-energy/neutronics_workflow/raw/main/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
-        local_filename = "dagmc_bigger.h5m"
+#         local_filename = "dagmc_bigger.h5m"
 
-        if not Path(local_filename).is_file():
+#         if not Path(local_filename).is_file():
 
-            r = requests.get(url, stream=True)
-            with open(local_filename, "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024):
-                    if chunk:
-                        f.write(chunk)
+#             r = requests.get(url, stream=True)
+#             with open(local_filename, "wb") as f:
+#                 for chunk in r.iter_content(chunk_size=1024):
+#                     if chunk:
+#                         f.write(chunk)
 
     # def test_create_initial_source_file(self):
     #     """Creates an initial_source.h5 from a point source"""
@@ -82,39 +82,6 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
     #         openmc_dagmc_wrapper.extract_points_from_initial_source(view_plane="coucou")
 
     #     self.assertRaises(ValueError, incorrect_viewplane)
-
-    def test_find_materials_in_h5_file(self):
-        """exports a h5m with specific material tags and checks they are
-        found using the find_material_groups_in_h5m utility function"""
-
-        list_of_mats = openmc_dagmc_wrapper.find_material_groups_in_h5m(
-            filename="dagmc_bigger.h5m"
-        )
-
-        assert len(list_of_mats) == 10
-        assert "mat:pf_coil_case_mat" in list_of_mats
-        assert "mat:center_column_shield_mat" in list_of_mats
-        assert "mat:blanket_rear_wall_mat" in list_of_mats
-        assert "mat:divertor_mat" in list_of_mats
-        assert "mat:graveyard" in list_of_mats
-        assert "mat:tf_coil_mat" in list_of_mats
-        assert "mat:pf_coil_mat" in list_of_mats
-        assert "mat:inboard_tf_coils_mat" in list_of_mats
-        assert "mat:blanket_mat" in list_of_mats
-        assert "mat:firstwall_mat" in list_of_mats
-
-    def test_find_volume_ids_in_h5_file(self):
-        """exports a h5m with a known number of volumes and checks they are
-        found using the find_volume_ids_in_h5m utility function"""
-
-        list_of_mats = openmc_dagmc_wrapper.find_volume_ids_in_h5m(
-            filename="dagmc_bigger.h5m"
-        )
-
-        assert len(list_of_mats) == len(
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
-        )
-        assert 1 in list_of_mats
 
     # def test_create_initial_particles(self):
     #     """Creates an initial source file using create_initial_particles utility

--- a/tests/test_reactor_neutronics.py
+++ b/tests/test_reactor_neutronics.py
@@ -29,7 +29,6 @@ class TestNeutronicsModelWithReactor(unittest.TestCase):
             "center_column_shield_mat": "Be",
             "blanket_rear_wall_mat": "Be",
             "divertor_mat": "Be",
-            "graveyard": "Be",
             "tf_coil_mat": "Be",
             "pf_coil_mat": "Be",
             "inboard_tf_coils_mat": "Be",

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -30,7 +30,6 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             "center_column_shield_mat": "Be",
             "blanket_rear_wall_mat": "Be",
             "divertor_mat": "Be",
-            "graveyard": "Be",
             "tf_coil_mat": "Be",
             "pf_coil_mat": "Be",
             "inboard_tf_coils_mat": "Be",


### PR DESCRIPTION
This makes use of the a new package called dagmc_h5m_file_inspector https://github.com/fusion-energy/dagmc_h5m_file_inspector

This allows for a fair amount of code removal and test removal from the utils as this is now done in the dagmc_h5m_file_inspector package.

This modularisation of the logic helps keep openmc-dagmc-wrapper concise and focused on the remit, easier to maintain etc