### PR TITLE
added 2d mesh tally test

### DIFF
--- a/tests/test_tallies/test_mesh_tally_2d.py
+++ b/tests/test_tallies/test_mesh_tally_2d.py
@@ -1,0 +1,92 @@
+
+import tarfile
+import unittest
+import urllib.request
+from pathlib import Path
+
+import openmc
+import openmc_dagmc_wrapper as odw
+from openmc_plasma_source import FusionRingSource
+
+
+class TestMeshTally2D(unittest.TestCase):
+    """Tests the MeshTally2D class functionality"""
+
+    def setUp(self):
+
+        if not Path("tests/v0.0.2.tar.gz").is_file():
+            url = "https://github.com/fusion-energy/neutronics_workflow/archive/refs/tags/v0.0.2.tar.gz"
+            urllib.request.urlretrieve(url, "tests/v0.0.2.tar.gz")
+
+        tar = tarfile.open("tests/v0.0.2.tar.gz", "r:gz")
+        tar.extractall("tests")
+        tar.close()
+
+        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+
+    def test_incorrect_mesh_tally_2d(self):
+        """Set a mesh_tally_2d that is not accepted which should raise an
+        error"""
+        def incorrect_mesh_tally_2d():
+            odw.MeshTally2D("coucou", plane="xy")
+
+        self.assertRaises(ValueError, incorrect_mesh_tally_2d)
+
+    def test_incorrect_mesh_tally_2d_type(self):
+        """Set a mesh_tally_2d that is the wrong type which should raise an
+        error"""
+        def incorrect_mesh_tally_2d_type():
+            odw.MeshTally2D(1, plane="xy")
+
+        self.assertRaises(TypeError, incorrect_mesh_tally_2d_type)
+
+    
+    def test_shape_of_resulting_png(self):
+        """Runs a simulation with a 2d mesh tally and checks png images are
+        produced"""
+
+        geometry = odw.Geometry(h5m_filename=self.h5m_filename_smaller)
+        materials = odw.Materials(
+            h5m_filename=self.h5m_filename_smaller,
+            correspondence_dict={
+                "mat1": "Be",
+            },
+        )
+        tally1 = odw.MeshTally2D(
+            tally_type="flux",
+            plane="xy",
+            bounding_box=self.h5m_filename_smaller,
+            mesh_resolution=(10, 200)
+        )
+        tally2 = odw.MeshTally2D(
+            tally_type="flux",
+            plane="xz",
+            bounding_box=self.h5m_filename_smaller,
+            mesh_resolution=(20, 100)
+        )
+        tally3 = odw.MeshTally2D(
+            tally_type="flux",
+            plane="yz",
+            bounding_box=self.h5m_filename_smaller,
+            mesh_resolution=(30, 500)
+        )
+
+        tallies = openmc.Tallies([tally1, tally2, tally3])
+
+        settings = odw.FusionSettings()
+        settings.batches = 2
+        settings.particles = 100
+        settings.photon_transport = False
+        settings.source = FusionRingSource(fuel="DT", radius=1)
+
+        my_model = openmc.Model(
+            materials=materials, geometry=geometry, settings=settings, tallies=tallies
+        )
+        statepoint_file = my_model.run()
+
+        odw.process_results(statepoint_file, fusion_power=1e9)
+
+        assert Path('flux_on_2D_mesh_xy.png').exists()
+        assert Path('flux_on_2D_mesh_xz.png').exists()
+        assert Path('flux_on_2D_mesh_yz.png').exists()

--- a/tests/test_tallies/test_mesh_tally_2d.py
+++ b/tests/test_tallies/test_mesh_tally_2d.py
@@ -41,7 +41,6 @@ class TestMeshTally2D(unittest.TestCase):
 
         self.assertRaises(TypeError, incorrect_mesh_tally_2d_type)
 
-    
     def test_shape_of_resulting_png(self):
         """Runs a simulation with a 2d mesh tally and checks png images are
         produced"""
@@ -81,8 +80,10 @@ class TestMeshTally2D(unittest.TestCase):
         settings.source = FusionRingSource(fuel="DT", radius=1)
 
         my_model = openmc.Model(
-            materials=materials, geometry=geometry, settings=settings, tallies=tallies
-        )
+            materials=materials,
+            geometry=geometry,
+            settings=settings,
+            tallies=tallies)
         statepoint_file = my_model.run()
 
         odw.process_results(statepoint_file, fusion_power=1e9)

--- a/tests/test_tallies/test_mesh_tally_3d.py
+++ b/tests/test_tallies/test_mesh_tally_3d.py
@@ -1,3 +1,4 @@
+
 import tarfile
 import unittest
 import urllib.request
@@ -7,8 +8,8 @@ import openmc
 import openmc_dagmc_wrapper as odw
 
 
-class TestMeshTallies(unittest.TestCase):
-    """Tests the MeshTallies class functionality"""
+class TestMeshTally3D(unittest.TestCase):
+    """Tests the MeshTally3D class functionality"""
 
     def setUp(self):
 
@@ -22,22 +23,6 @@ class TestMeshTallies(unittest.TestCase):
 
         self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
         self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
-
-    def test_incorrect_mesh_tally_2d(self):
-        """Set a mesh_tally_2d that is not accepted which should raise an
-        error"""
-        def incorrect_mesh_tally_2d():
-            odw.MeshTally2D("coucou", plane="xy")
-
-        self.assertRaises(ValueError, incorrect_mesh_tally_2d)
-
-    def test_incorrect_mesh_tally_2d_type(self):
-        """Set a mesh_tally_2d that is the wrong type which should raise an
-        error"""
-        def incorrect_mesh_tally_2d_type():
-            odw.MeshTally2D(1, plane="xy")
-
-        self.assertRaises(TypeError, incorrect_mesh_tally_2d_type)
 
     def test_incorrect_mesh_tally_3d(self):
         """Set a mesh_tally_3d that is not accepted which should raise an


### PR DESCRIPTION
Splits up the test_mesh_tallies.py test into test_mesh_tallies_2d and  test_mesh_tallies_3d.

Also adds a test to the test_mesh_tallies_2d that checks the png files are produced at the end of the simulation