### PR TITLE
Fix bounding box tests

### DIFF
--- a/tests/test_neutronics_utils.py
+++ b/tests/test_neutronics_utils.py
@@ -80,12 +80,12 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3
         assert len(bounding_box[1]) == 3
-        assert bounding_box[0][0] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[0][1] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[0][2] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[1][0] == pytest.approx(10005, abs=0.1)
-        assert bounding_box[1][1] == pytest.approx(10005, abs=0.1)
-        assert bounding_box[1][2] == pytest.approx(10005, abs=0.1)
+        assert bounding_box[0][0] == pytest.approx(-10005, abs=1)
+        assert bounding_box[0][1] == pytest.approx(-10005, abs=1)
+        assert bounding_box[0][2] == pytest.approx(-10005, abs=1)
+        assert bounding_box[1][0] == pytest.approx(10005, abs=1)
+        assert bounding_box[1][1] == pytest.approx(10005, abs=1)
+        assert bounding_box[1][2] == pytest.approx(10005, abs=1)
 
     def test_bounding_box_size_2(self):
 
@@ -95,12 +95,12 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3
         assert len(bounding_box[1]) == 3
-        assert bounding_box[0][0] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[0][1] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[0][2] == pytest.approx(-10005, abs=0.1)
-        assert bounding_box[1][0] == pytest.approx(10005, abs=0.1)
-        assert bounding_box[1][1] == pytest.approx(10005, abs=0.1)
-        assert bounding_box[1][2] == pytest.approx(10005, abs=0.1)
+        assert bounding_box[0][0] == pytest.approx(-10005, abs=1)
+        assert bounding_box[0][1] == pytest.approx(-10005, abs=1)
+        assert bounding_box[0][2] == pytest.approx(-10005, abs=1)
+        assert bounding_box[1][0] == pytest.approx(10005, abs=1)
+        assert bounding_box[1][1] == pytest.approx(10005, abs=1)
+        assert bounding_box[1][2] == pytest.approx(10005, abs=1)
 
     # def test_create_initial_source_file(self):
     #     """Creates an initial_source.h5 from a point source"""


### PR DESCRIPTION
This PR should fix the current failing tests in master.


Although there is a 404 not found error that needs to be fixed. As if CircleCI wasn't able to access the archives.

Which is weird cause the following works locally:

```python
import urllib.request
from pathlib import Path


if not Path("tests/v0.0.2.tar.gz").is_file():
    url = "https://github.com/fusion-energy/neutronics_workflow/archive/refs/tags/v0.0.2.tar.gz"
    urllib.request.urlretrieve(url, "tests/v0.0.2.tar.gz")
```